### PR TITLE
Support Shareable Links for Bills

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,16 @@ Swiping on legislation.
 
 ## Project Objectives
 
-Educate, engage, and reimagine political agency and concensus.
+Educate, engage, and reimagine political agency and consensus.
+
+## Run on Local
+
+To start the front-end service run:
+
+`elm-app start`.
+
+
+To start the API service run:
+
+`netlify dev`
+

--- a/elmapp.config.js
+++ b/elmapp.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  proxy: "http://localhost:8888",
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,12 @@
         "ethers": "^5.7.0",
         "fp-ts": "^2.16.0",
         "google-auth-library": "^8.8.0",
+        "http": "^0.0.1-security",
+        "http-proxy": "^1.18.1",
         "http-status-codes": "^2.2.0",
         "io-ts": "^2.2.20",
         "prettier": "^2.8.8",
+        "request": "^2.88.2",
         "typescript": "^4.9.5"
       },
       "devDependencies": {
@@ -8669,6 +8672,11 @@
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
+    },
+    "node_modules/http": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
+      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -24480,6 +24488,11 @@
         "domutils": "^2.5.2",
         "entities": "^2.0.0"
       }
+    },
+    "http": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
+      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
     },
     "http-deceiver": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,16 @@
     "@types/node": "^14.18.48",
     "create-elm-app": "^5.22.0",
     "dotenv": "^16.0.3",
+    "ethers": "^5.7.0",
     "fp-ts": "^2.16.0",
     "google-auth-library": "^8.8.0",
+    "http": "^0.0.1-security",
+    "http-proxy": "^1.18.1",
     "http-status-codes": "^2.2.0",
     "io-ts": "^2.2.20",
     "prettier": "^2.8.8",
-    "typescript": "^4.9.5",
-    "ethers": "^5.7.0"
+    "request": "^2.88.2",
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "elm-tailwind-modules": "^0.5.0",

--- a/src/Bill.elm
+++ b/src/Bill.elm
@@ -1,4 +1,4 @@
-module Bill exposing (BillRes, Model, Sponsor, blank, decoder, encode, toBillId, toUrl, view)
+module Bill exposing (BillRes, Model, Sponsor, blank, decoder, encode, toBillId, toJsonFromIds, toUrl, view)
 
 import Html.Styled exposing (Html, a, button, div, h1, h2, h3, h4, p, span, text)
 import Html.Styled.Attributes exposing (class, css, href, target)
@@ -6,6 +6,7 @@ import Html.Styled.Events exposing (onClick)
 import Json.Decode exposing (Decoder, field, int, list, map, map2, map3, map4, map5, map6, map7, maybe, string)
 import Json.Encode as Encode exposing (encode, object)
 import Tailwind.Utilities as T
+import Url.Builder as Url
 
 
 type alias PolicyArea =
@@ -156,6 +157,36 @@ view showSponsor sponsorShow bill =
 toBillId : Model -> String
 toBillId model =
     String.fromInt model.congress ++ "-" ++ model.type_ ++ "-" ++ model.number
+
+
+toJsonUrl : String -> Model -> String
+toJsonUrl apiKey model =
+    Url.crossOrigin
+        "https://api.congress.gov"
+        [ "v3"
+        , "bill"
+        , String.fromInt model.congress
+        , String.toLower model.type_
+        , model.number
+        ]
+        [ Url.string "format" "json"
+        , Url.string "apiKey" apiKey
+        ]
+
+
+toJsonFromIds : String -> String -> String -> String
+toJsonFromIds apiKey type_ number =
+    Url.crossOrigin
+        "https://api.congress.gov"
+        [ "v3"
+        , "bill"
+        , String.fromInt 118
+        , String.toLower type_
+        , number
+        ]
+        [ Url.string "format" "json"
+        , Url.string "api_key" apiKey
+        ]
 
 
 toUrl : Model -> String

--- a/src/BillMetadata.elm
+++ b/src/BillMetadata.elm
@@ -1,10 +1,10 @@
 module BillMetadata exposing (BillMetadata, BillMetadataRes, decoder)
 
-import Json.Decode exposing (Decoder, field, list, map, map2, map3, string)
+import Json.Decode exposing (Decoder, field, list, map, map2, map3, map4, string)
 
 
 type alias BillMetadata =
-    { title : String, url : String, number : String }
+    { title : String, url : String, number : String, type_ : String }
 
 
 type alias BillMetadataRes =
@@ -19,10 +19,11 @@ type alias Pagination =
 
 billDecoder : Decoder BillMetadata
 billDecoder =
-    map3 BillMetadata
+    map4 BillMetadata
         (field "title" string)
         (field "url" string)
         (field "number" string)
+        (field "type" string)
 
 
 billListDecoder : Decoder (List BillMetadata)

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,4 +1,12 @@
-module Route exposing (Route(..), billToUrl, fromUrl, route, toRoute, toUrlString)
+module Route exposing
+    ( Route(..)
+    , billIdsToUrl
+    , billToUrl
+    , fromUrl
+    , route
+    , toRoute
+    , toUrlString
+    )
 
 import Bill
 import Url exposing (Url)
@@ -16,6 +24,8 @@ route : Parser (Route -> a) a
 route =
     oneOf
         [ map Home top
+
+        -- /bill/<type>/<number>
         , map Bill (s "bill" </> string </> string)
         ]
 
@@ -48,3 +58,8 @@ toRoute string =
 billToUrl : Bill.Model -> String
 billToUrl bill =
     absolute [ "bill", bill.type_, bill.number ] []
+
+
+billIdsToUrl : String -> String -> String
+billIdsToUrl type_ number =
+    absolute [ "bill", type_, number ] []

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,6 @@ app.ports.claimTokens.subscribe(async function () {
 
 app.ports.getAuthToken.subscribe(function (googleClientId) {
   console.log("log on clicked");
-  console.log(googleClientId);
   google.accounts.id.initialize({
     client_id: googleClientId,
     callback: function (obj) {


### PR DESCRIPTION
The following changes implement a crude linking scheme where bills can be shared by legiswipe users. The unauthenticated users that load the bill will be able to read it but not vote until login, which is one click in the same area that the vote buttons will appear after login.